### PR TITLE
This updates the scraper to work with the current version of baseball-reference.com

### DIFF
--- a/brscraper.py
+++ b/brscraper.py
@@ -52,7 +52,7 @@ class BRScraper:
                         header_name = base_header_name + "_" + str(i)
                     if verbose: 
                         if base_header_name == "":
-                            print ("Empty header relabeled as %s" % header_name)
+                            print("Empty header relabeled as %s" % header_name)
                         else:
                             print("Header %s relabeled as %s" % (base_header_name, header_name))
                 else:

--- a/brscraper.py
+++ b/brscraper.py
@@ -35,7 +35,7 @@ class BRScraper:
         for table in tables:
             
             if table_ids != None and table["id"] not in table_ids: continue
-            if verbose: print ("Processing table " + table["id"])
+            if verbose: print("Processing table " + table["id"])
             data[table["id"]] = []
             
             headers = table.find("thead").find_all("th")

--- a/brscraper.py
+++ b/brscraper.py
@@ -17,12 +17,12 @@ class BRScraper:
         """
 
         def is_parseable_table(tag):
-            if not tag.has_key("class"): return False
+            if not tag.has_attr("class"): return False
             return tag.name == "table" and "stats_table" in tag["class"] and "sortable" in tag["class"]
 
         def is_parseable_row(tag):
             if not tag.name == "tr": return False
-            if not tag.has_key("class"): return True  # permissive
+            if not tag.has_attr("class"): return True  # permissive
             return "league_average_table" not in tag["class"] and "stat_total" not in tag["class"]
 
         if isinstance(table_ids, str): table_ids = [table_ids]

--- a/brscraper.py
+++ b/brscraper.py
@@ -61,7 +61,7 @@ class BRScraper:
             
             rows = table.find("tbody").find_all(is_parseable_row)
             for row in rows:
-                entries = row.find_all("td")
+                entries = row.find_all(["td", "th"])
                 entry_data = []
                 for entry in entries:
                     if entry.string == None:

--- a/brscraper.py
+++ b/brscraper.py
@@ -54,7 +54,7 @@ class BRScraper:
                         if base_header_name == "":
                             print ("Empty header relabeled as %s" % header_name)
                         else:
-                            print ("Header %s relabeled as %s" % (base_header_name, header_name))
+                            print("Header %s relabeled as %s" % (base_header_name, header_name))
                 else:
                     header_name = base_header_name
                 header_names.append(header_name)

--- a/brscraper.py
+++ b/brscraper.py
@@ -1,6 +1,6 @@
 
 from bs4 import BeautifulSoup
-import urllib2
+from urllib.request import urlopen
 
 class BRScraper:
     
@@ -27,7 +27,7 @@ class BRScraper:
 
         if isinstance(table_ids, str): table_ids = [table_ids]
 
-        soup = BeautifulSoup(urllib2.urlopen(self.server_url + resource))
+        soup = BeautifulSoup(urlopen(self.server_url + resource), 'lxml')
         tables = soup.find_all(is_parseable_table)
         data = {}
 
@@ -35,7 +35,7 @@ class BRScraper:
         for table in tables:
             
             if table_ids != None and table["id"] not in table_ids: continue
-            if verbose: print "Processing table " + table["id"]
+            if verbose: print ("Processing table " + table["id"])
             data[table["id"]] = []
             
             headers = table.find("thead").find_all("th")
@@ -52,9 +52,9 @@ class BRScraper:
                         header_name = base_header_name + "_" + str(i)
                     if verbose: 
                         if base_header_name == "":
-                            print "Empty header relabeled as %s" % header_name
+                            print ("Empty header relabeled as %s" % header_name)
                         else:
-                            print "Header %s relabeled as %s" % (base_header_name, header_name)
+                            print ("Header %s relabeled as %s" % (base_header_name, header_name))
                 else:
                     header_name = base_header_name
                 header_names.append(header_name)


### PR DESCRIPTION
There was previously an issue where the scraper would drop the first row of the table body because it's now a `<th>`, rather than a `<tb>`, causing the outputted dictionary keys to be mismatched with incorrect values. For instance, just try the example in the README, and it'll give you an ERA of 30, rather than the actual ERA of 2.89. This fixes that problem by including the `<th>` tag in the row searching process.

It also switches away from the deprecated function `has_key`, and instead uses `has_attr`.